### PR TITLE
로그인, 회원가입, Dio Interceptor 토큰 관리 및 유저 정보 불러오기

### DIFF
--- a/lib/common/constant/constant.dart
+++ b/lib/common/constant/constant.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'dart:io';
 
 const basePath = 'assets/image';
 const baseImageSvgPath = "assets/svg";
@@ -10,3 +11,7 @@ const ACCESS_TOKEN = "acessToken";
 const REFRESH_TOKEN = "refreshToken";
 
 final storage = FlutterSecureStorage();
+
+const emulatorIp = "10.0.2.2:8000";
+const simulatorIp = "127.0.0.1:8000";
+final ip = Platform.isIOS ? simulatorIp : emulatorIp;

--- a/lib/common/constant/constant.dart
+++ b/lib/common/constant/constant.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 const basePath = 'assets/image';
 const baseImageSvgPath = "assets/svg";
 
-final dio = Dio();
+// final dio = Dio();
 
 const ACCESS_TOKEN = "acessToken";
 const REFRESH_TOKEN = "refreshToken";

--- a/lib/common/constant/constant.dart
+++ b/lib/common/constant/constant.dart
@@ -1,11 +1,8 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'dart:io';
 
 const basePath = 'assets/image';
 const baseImageSvgPath = "assets/svg";
-
-// final dio = Dio();
 
 const ACCESS_TOKEN = "acessToken";
 const REFRESH_TOKEN = "refreshToken";

--- a/lib/common/dio/dio.dart
+++ b/lib/common/dio/dio.dart
@@ -33,13 +33,12 @@ class CustomInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     final refreshToken = await storage.read(key: REFRESH_TOKEN);
-    print("디오 에러로 인해 $refreshToken");
+
     if (refreshToken == null) {
       return handler.reject(err);
     }
     final isPath = err.requestOptions.path == 'token/refersh';
 
-    // 토큰 검정 실패시
     if (err.response?.statusCode == 401 && !isPath) {
       final dio = Dio();
 
@@ -69,7 +68,6 @@ class CustomInterceptor extends Interceptor {
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
-    // TODO: implement onResponse
     super.onResponse(response, handler);
   }
 }

--- a/lib/common/dio/dio.dart
+++ b/lib/common/dio/dio.dart
@@ -30,7 +30,7 @@ class CustomInterceptor extends Interceptor {
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     // TODO: implement onError
     final refreshToken = await storage.read(key: REFRESH_TOKEN);
-
+    print("dio Error");
     if (refreshToken == null) {
       return handler.reject(err);
     }
@@ -40,7 +40,7 @@ class CustomInterceptor extends Interceptor {
       final dio = Dio();
 
       try {
-        final res = await dio.post("http://10.0.2.2:8000/users/oauth/refresh",
+        final res = await dio.post("http://$ip/token/refresh",
             options: Options(headers: {
               "refresh_token": "string",
               "grant_type": "Bearer",
@@ -49,7 +49,7 @@ class CustomInterceptor extends Interceptor {
         final accessToken = res.data["result"]["result"]["access_token"];
         final options = err.requestOptions;
 
-        options.headers.addAll({'Authorization': 'Bearer $accessToken'});
+        options.headers.addAll({'authorization': 'Bearer $accessToken'});
 
         await storage.write(key: ACCESS_TOKEN, value: accessToken);
 

--- a/lib/common/dio/dio.dart
+++ b/lib/common/dio/dio.dart
@@ -37,9 +37,9 @@ class CustomInterceptor extends Interceptor {
     if (refreshToken == null) {
       return handler.reject(err);
     }
-    final isPath = err.requestOptions.path == 'token/refersh';
+    final isRefereshTokenPath = err.requestOptions.path == 'token/refersh';
 
-    if (err.response?.statusCode == 401 && !isPath) {
+    if (err.response?.statusCode == 401 && !isRefereshTokenPath) {
       final dio = Dio();
 
       try {

--- a/lib/common/dio/dio.dart
+++ b/lib/common/dio/dio.dart
@@ -33,23 +33,23 @@ class CustomInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     final refreshToken = await storage.read(key: REFRESH_TOKEN);
-    print("dio onError");
+    print("디오 에러로 인해 $refreshToken");
     if (refreshToken == null) {
       return handler.reject(err);
     }
+    final isPath = err.requestOptions.path == 'token/refersh';
+
     // 토큰 검정 실패시
-    if (err.response?.statusCode == 401) {
-      // refreshToken
+    if (err.response?.statusCode == 401 && !isPath) {
       final dio = Dio();
 
       try {
-        final res = await dio.get("http://$ip/token/refresh",
+        final res = await dio.get("http://10.0.2.2:8000/token/refresh",
             options: Options(headers: {
-              "refresh_token": "string",
-              "grant_type": "Bearer",
+              "authorization": "Bearer $refreshToken",
             }));
 
-        final accessToken = res.data["result"]["result"]["access_token"];
+        final accessToken = res.data["access_token"];
         final options = err.requestOptions;
 
         options.headers.addAll({'authorization': 'Bearer $accessToken'});

--- a/lib/common/services/token_refresh_service.dart
+++ b/lib/common/services/token_refresh_service.dart
@@ -5,12 +5,10 @@ import 'package:me_mind/user/model/user_signin_model.dart';
 
 class TokenRefreshService {
   Future refresh() async {
-    final dio = Dio();
+    final dio = Dio(BaseOptions(baseUrl: "http://10.0.2.2:8000/", headers: {}));
 
     String url = 'token/refresh';
 
-    dio.options.baseUrl = "http://10.0.2.2:8000/";
-    dio.options.headers.clear();
     dio.interceptors.add(CustomInterceptor(storage: storage));
     dio.options.headers.addAll({'refreshToken': true});
 

--- a/lib/common/services/token_refresh_service.dart
+++ b/lib/common/services/token_refresh_service.dart
@@ -27,7 +27,6 @@ class TokenRefreshService {
         return null;
       }
     } on DioException catch (error) {
-      print("token Error: dio get error:$error");
       return null;
     } catch (e) {
       return null;

--- a/lib/common/services/token_refresh_service.dart
+++ b/lib/common/services/token_refresh_service.dart
@@ -1,17 +1,18 @@
 import 'package:dio/dio.dart';
 import 'package:me_mind/common/constant/constant.dart';
 import 'package:me_mind/common/dio/dio.dart';
+import 'package:me_mind/user/model/user_signin_model.dart';
 
-import 'package:me_mind/settings/model/user_info_model.dart';
-
-class UserInfoService {
-  Future findUser() async {
+class TokenRefreshService {
+  Future refresh() async {
     final dio = Dio();
 
-    dio.interceptors.add(CustomInterceptor(storage: storage));
+    String url = 'token/refresh';
+
+    dio.options.baseUrl = "http://10.0.2.2:8000/";
     dio.options.headers.clear();
-    dio.options.headers.addAll({'accessToken': true});
-    String url = "http://$ip/users/me/";
+    dio.interceptors.add(CustomInterceptor(storage: storage));
+    dio.options.headers.addAll({'refreshToken': true});
 
     try {
       final response = await dio.get(url);
@@ -19,14 +20,14 @@ class UserInfoService {
       if (response.statusCode == 200) {
         var result = response.data;
 
-        UserInfoModel userInfo = UserInfoModel.fromJson(result);
+        SignInResult tokenResult = SignInResult.fromJson(result);
 
-        return userInfo;
+        return tokenResult;
       } else {
         return null;
       }
     } on DioException catch (error) {
-      print("UserInfo Search: dio get error:$error");
+      print("token Error: dio get error:$error");
       return null;
     } catch (e) {
       return null;

--- a/lib/common/view/splash_screen.dart
+++ b/lib/common/view/splash_screen.dart
@@ -19,9 +19,7 @@ class SplashScreen extends StatefulWidget {
 class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
-    //deleteToken();
     userMe();
     appLoading();
   }
@@ -35,37 +33,26 @@ class _SplashScreenState extends State<SplashScreen> {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final bool? isTutorial = prefs.getBool("isTutorial");
 
-    final dio = Dio();
-
     if (isTutorial == false || isTutorial == null) {
       Navigator.of(context)
           .push(MaterialPageRoute(builder: (_) => OnBoardingScreen()));
     } else {
-      // 튜토리얼 한 경우
-      final accessToken = await storage.read(key: ACCESS_TOKEN);
-      final refreshToken = await storage.read(key: REFRESH_TOKEN);
-
       try {
         final tokenResponse = await TokenRefreshService().refresh();
 
         await storage.write(
             key: ACCESS_TOKEN, value: tokenResponse.accessToken);
 
-        // 성공했을 때 유저의 개인정보를 내부 저장소에 저장
         final userInfo = await UserInfoService().findUser();
-        print("유저 정보");
 
-        // nickname, email ? 내부 저장소가 아니라 전역?
         if (userInfo.nickname != null || userInfo.email != null) {
           await prefs.setString("USER_NICKNAME", userInfo.nickname);
           await prefs.setString("USER_EMAIL", userInfo.email);
         }
 
-        // 통신이 되고 write 성공했으면 메인으로
         Navigator.of(context)
             .push(MaterialPageRoute(builder: (_) => MainScreen()));
       } catch (e) {
-        //통신이 실패했다면
         Navigator.of(context)
             .push(MaterialPageRoute(builder: (_) => SignInScreen()));
       }

--- a/lib/common/view/splash_screen.dart
+++ b/lib/common/view/splash_screen.dart
@@ -5,6 +5,7 @@ import 'package:me_mind/common/layout/default_layout.dart';
 import 'package:me_mind/common/services/token_refresh_service.dart';
 import 'package:me_mind/common/view/on_boarding.dart';
 import 'package:me_mind/screen/main/s_main.dart';
+import 'package:me_mind/settings/services/userinfo_service.dart';
 import 'package:me_mind/user/view/s_signin.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -22,7 +23,7 @@ class _SplashScreenState extends State<SplashScreen> {
     super.initState();
     //deleteToken();
     userMe();
-    checkToken();
+    appLoading();
   }
 
   void deleteToken() async {
@@ -30,7 +31,7 @@ class _SplashScreenState extends State<SplashScreen> {
     await prefs.remove("isTutorial");
   }
 
-  void checkToken() async {
+  void appLoading() async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final bool? isTutorial = prefs.getBool("isTutorial");
 
@@ -49,6 +50,16 @@ class _SplashScreenState extends State<SplashScreen> {
 
         await storage.write(
             key: ACCESS_TOKEN, value: tokenResponse.accessToken);
+
+        // 성공했을 때 유저의 개인정보를 내부 저장소에 저장
+        final userInfo = await UserInfoService().findUser();
+        print("유저 정보");
+
+        // nickname, email ? 내부 저장소가 아니라 전역?
+        if (userInfo.nickname != null || userInfo.email != null) {
+          await prefs.setString("USER_NICKNAME", userInfo.nickname);
+          await prefs.setString("USER_EMAIL", userInfo.email);
+        }
 
         // 통신이 되고 write 성공했으면 메인으로
         Navigator.of(context)

--- a/lib/common/view/splash_screen.dart
+++ b/lib/common/view/splash_screen.dart
@@ -47,7 +47,7 @@ class _SplashScreenState extends State<SplashScreen> {
         final response = await dio.get('http://$ip/token/refresh',
             options:
                 Options(headers: {'authorization': "Bearer $refreshToken"}));
-
+        print(response.data);
         await storage.write(
             key: ACCESS_TOKEN, value: response.data['access_token']);
 

--- a/lib/common/view/splash_screen.dart
+++ b/lib/common/view/splash_screen.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:me_mind/common/constant/constant.dart';
 import 'package:me_mind/common/layout/default_layout.dart';
+import 'package:me_mind/common/services/token_refresh_service.dart';
 import 'package:me_mind/common/view/on_boarding.dart';
 import 'package:me_mind/screen/main/s_main.dart';
 import 'package:me_mind/user/view/s_signin.dart';
@@ -44,12 +45,10 @@ class _SplashScreenState extends State<SplashScreen> {
       final refreshToken = await storage.read(key: REFRESH_TOKEN);
 
       try {
-        final response = await dio.get('http://$ip/token/refresh',
-            options:
-                Options(headers: {'authorization': "Bearer $refreshToken"}));
-        print(response.data);
+        final tokenResponse = await TokenRefreshService().refresh();
+
         await storage.write(
-            key: ACCESS_TOKEN, value: response.data['access_token']);
+            key: ACCESS_TOKEN, value: tokenResponse.accessToken);
 
         // 통신이 되고 write 성공했으면 메인으로
         Navigator.of(context)

--- a/lib/report/services/search_service.dart
+++ b/lib/report/services/search_service.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:me_mind/common/constant/constant.dart';
 import 'package:me_mind/report/model/report_search/report_search_model.dart';
 
 class SearchService {

--- a/lib/report/services/search_service.dart
+++ b/lib/report/services/search_service.dart
@@ -4,6 +4,8 @@ import 'package:me_mind/report/model/report_search/report_search_model.dart';
 
 class SearchService {
   Future search(String keyword) async {
+    final dio = Dio();
+
     String uriKeyword = Uri.encodeQueryComponent(keyword);
     String url = 'report/search/$uriKeyword';
 

--- a/lib/settings/model/user_info_model.dart
+++ b/lib/settings/model/user_info_model.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'user_info_model.g.dart';
+
+@JsonSerializable()
+class UserInfoModel {
+  final String? email;
+  final int? id;
+  final String? username;
+  final String? nickname;
+  @JsonKey(name: "is_active")
+  final bool? isActive;
+  final String? role;
+  @JsonKey(name: "created_at")
+  final String? createdAt;
+  @JsonKey(name: "updatedAt")
+  final String? updatedAt;
+
+  UserInfoModel({
+    this.email,
+    this.id,
+    this.username,
+    this.nickname,
+    this.isActive,
+    this.role,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory UserInfoModel.fromJson(Map<String, dynamic> json) =>
+      _$UserInfoModelFromJson(json);
+}

--- a/lib/settings/model/user_info_model.g.dart
+++ b/lib/settings/model/user_info_model.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_info_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UserInfoModel _$UserInfoModelFromJson(Map<String, dynamic> json) =>
+    UserInfoModel(
+      email: json['email'] as String?,
+      id: json['id'] as int?,
+      username: json['username'] as String?,
+      nickname: json['nickname'] as String?,
+      isActive: json['is_active'] as bool?,
+      role: json['role'] as String?,
+      createdAt: json['created_at'] as String?,
+      updatedAt: json['updatedAt'] as String?,
+    );
+
+Map<String, dynamic> _$UserInfoModelToJson(UserInfoModel instance) =>
+    <String, dynamic>{
+      'email': instance.email,
+      'id': instance.id,
+      'username': instance.username,
+      'nickname': instance.nickname,
+      'is_active': instance.isActive,
+      'role': instance.role,
+      'created_at': instance.createdAt,
+      'updatedAt': instance.updatedAt,
+    };

--- a/lib/settings/services/userinfo_service.dart
+++ b/lib/settings/services/userinfo_service.dart
@@ -16,15 +16,11 @@ class UserInfoService {
     try {
       final response = await dio.get(url);
 
-      if (response.statusCode == 200) {
-        var result = response.data;
+      var result = response.data;
 
-        UserInfoModel userInfo = UserInfoModel.fromJson(result);
+      UserInfoModel userInfo = UserInfoModel.fromJson(result);
 
-        return userInfo;
-      } else {
-        return null;
-      }
+      return userInfo;
     } on DioException catch (error) {
       return null;
     } catch (e) {

--- a/lib/settings/services/userinfo_service.dart
+++ b/lib/settings/services/userinfo_service.dart
@@ -26,7 +26,6 @@ class UserInfoService {
         return null;
       }
     } on DioException catch (error) {
-      print("UserInfo Search: dio get error:$error");
       return null;
     } catch (e) {
       return null;

--- a/lib/settings/services/userinfo_service.dart
+++ b/lib/settings/services/userinfo_service.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:me_mind/common/constant/constant.dart';
+
+import 'package:me_mind/settings/model/user_info_model.dart';
+
+class UserInfoService {
+  Future findUser() async {
+    Response response;
+    // dio.interceptors.add(CustomInterceptor(storage: storage));
+    dio.options.headers.addAll({'accessToken': true});
+    String url = "http://$ip/users/me/";
+
+    try {
+      final accessToken = await storage.read(key: ACCESS_TOKEN);
+
+      response = await dio.get(url,
+          options: Options(headers: {'Authorization': "Bearer $accessToken"}));
+
+      if (response.statusCode == 200) {
+        var result = response.data;
+
+        UserInfoModel userInfo = UserInfoModel.fromJson(result);
+
+        return userInfo;
+      } else {
+        return null;
+      }
+    } on DioException catch (error) {
+      print("Report Search: dio get error:$error");
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/lib/settings/view/f_userinfo_form.dart
+++ b/lib/settings/view/f_userinfo_form.dart
@@ -102,6 +102,7 @@ class _UserInfoFormState extends State<UserInfoForm> {
   void initState() {
     // TODO: implement initState
     super.initState();
+    print(widget.userEmail);
     certifyTimer = CertifyTimer(timerCount: timerCount);
     nickname = "구르미조아";
     email = "";
@@ -135,7 +136,7 @@ class _UserInfoFormState extends State<UserInfoForm> {
                 height: 20,
               ),
               SeetingCustomTextFormField(
-                initialText: nickname,
+                initialText: widget.userNickname,
                 bgColor: theme.appColors.seedColor,
                 maxLength: 10,
                 labelText: "닉네임",

--- a/lib/settings/view/f_userinfo_form.dart
+++ b/lib/settings/view/f_userinfo_form.dart
@@ -12,7 +12,6 @@ import 'package:me_mind/common/store.dart';
 import 'package:me_mind/common/theme/custom_theme.dart';
 import 'package:me_mind/common/theme/custom_theme_holder.dart';
 import 'package:me_mind/common/view/splash_screen.dart';
-import 'package:me_mind/report/view/s_report.dart';
 import 'package:me_mind/screen/main/s_main.dart';
 import 'package:me_mind/settings/component/settings_custom_text_form.dart';
 import 'package:me_mind/settings/utils/phone_number_formatter.dart';
@@ -105,8 +104,7 @@ class _UserInfoFormState extends State<UserInfoForm> {
     super.initState();
     certifyTimer = CertifyTimer(timerCount: timerCount);
     nickname = "구르미조아";
-    email = "brainz.paek@gmail.com";
-    print(nickname);
+    email = "";
     _timer = Timer(const Duration(seconds: 0), () {});
   }
 
@@ -152,7 +150,7 @@ class _UserInfoFormState extends State<UserInfoForm> {
                 height: 12.0,
               ),
               SeetingCustomTextFormField(
-                initialText: email,
+                initialText: widget.userEmail,
                 bgColor: theme.appColors.seedColor,
                 labelText: "이메일",
                 readOnly: widget.isUpdate == false ? true : false,

--- a/lib/settings/view/f_userinfo_form.dart
+++ b/lib/settings/view/f_userinfo_form.dart
@@ -65,7 +65,6 @@ class _UserInfoFormState extends State<UserInfoForm> {
         isTimerStart = true;
       });
       _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-        print(timerCount);
         if (timerCount <= 0) {
           _timer.cancel();
           AlertDialogs(
@@ -100,12 +99,8 @@ class _UserInfoFormState extends State<UserInfoForm> {
 
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
-    print(widget.userEmail);
     certifyTimer = CertifyTimer(timerCount: timerCount);
-    nickname = "구르미조아";
-    email = "";
     _timer = Timer(const Duration(seconds: 0), () {});
   }
 

--- a/lib/settings/view/s_setting.dart
+++ b/lib/settings/view/s_setting.dart
@@ -16,6 +16,7 @@ import 'package:me_mind/common/view/splash_screen.dart';
 import 'package:me_mind/settings/component/certified_box.dart';
 import 'package:me_mind/settings/component/settings_menu.dart';
 import 'package:me_mind/settings/services/logout_service.dart';
+import 'package:me_mind/settings/services/userinfo_service.dart';
 import 'package:me_mind/settings/view/s_faqwebview_screen.dart';
 import 'package:me_mind/settings/view/s_setting_notification.dart';
 import 'package:me_mind/settings/view/s_setting_opinion.dart';
@@ -54,11 +55,17 @@ class _SettingState extends State<Settings> {
     }
   }
 
+  void getUserInfo() async {
+    final result = await UserInfoService().findUser();
+    print(result.username);
+  }
+
   @override
   void initState() {
     super.initState();
     setBottomIdx(3);
     getIsAuth();
+    getUserInfo();
   }
 
   @override

--- a/lib/settings/view/s_setting.dart
+++ b/lib/settings/view/s_setting.dart
@@ -39,7 +39,6 @@ class _SettingState extends State<Settings> {
   String userNickname = "";
 
   void handlePhoneAuth() {
-    print("폰 인증");
     setState(() {
       isPhoneAuth = true;
     });
@@ -49,7 +48,7 @@ class _SettingState extends State<Settings> {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
 
     bool? isAuth = await prefs.getBool('is_auth');
-    print(isAuth);
+
     if (isAuth != null) {
       setState(() {
         isPhoneAuth = isAuth;
@@ -62,7 +61,6 @@ class _SettingState extends State<Settings> {
     final nickname = await prefs.getString("USER_NICKNAME");
     final email = await prefs.getString("USER_EMAIL");
 
-    print("${userNickname} ${userEmail}");
     setState(() {
       userNickname = nickname ?? "";
       userEmail = email ?? "";
@@ -137,7 +135,6 @@ class _SettingState extends State<Settings> {
                                   BorderRadius.all(Radius.circular(13))),
                         ),
                         onPressed: () {
-                          // 구독 버튼
                           Navigator.push(
                               context,
                               MaterialPageRoute(
@@ -176,7 +173,6 @@ class _SettingState extends State<Settings> {
                 height: 65,
                 content: ListTile(
                   onTap: () {
-                    // 계정 정보 페이지로 이동하는 부분
                     Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -259,7 +255,6 @@ class _SettingState extends State<Settings> {
                 height: 65,
                 content: ListTile(
                   onTap: () {
-                    print("의견 보내기");
                     Navigator.push(
                         context,
                         MaterialPageRoute(

--- a/lib/settings/view/s_setting.dart
+++ b/lib/settings/view/s_setting.dart
@@ -310,14 +310,10 @@ class _SettingState extends State<Settings> {
                                   bgColor: theme.appColors.grayButtonBackground,
                                   content: "네",
                                   onSubmit: () async {
-                                    var response =
-                                        await LogoutService().logout();
-                                    if (response != null) {
-                                      await storage.deleteAll();
-                                      Navigator.of(context).push(
-                                          MaterialPageRoute(
-                                              builder: (_) => SplashScreen()));
-                                    }
+                                    await storage.deleteAll();
+                                    Navigator.of(context).push(
+                                        MaterialPageRoute(
+                                            builder: (_) => SplashScreen()));
                                   }),
                               AlertDialogButton(
                                   theme: theme,

--- a/lib/settings/view/s_setting.dart
+++ b/lib/settings/view/s_setting.dart
@@ -35,6 +35,8 @@ class Settings extends StatefulWidget {
 class _SettingState extends State<Settings> {
   final dio = Dio();
   bool isPhoneAuth = false;
+  String userEmail = "";
+  String userNickname = "";
 
   void handlePhoneAuth() {
     print("폰 인증");
@@ -56,8 +58,15 @@ class _SettingState extends State<Settings> {
   }
 
   void getUserInfo() async {
-    final result = await UserInfoService().findUser();
-    print(result.username);
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final nickname = await prefs.getString("USER_NICKNAME");
+    final email = await prefs.getString("USER_EMAIL");
+
+    print("${userNickname} ${userEmail}");
+    setState(() {
+      userNickname = nickname ?? "";
+      userEmail = email ?? "";
+    });
   }
 
   @override
@@ -173,6 +182,8 @@ class _SettingState extends State<Settings> {
                         MaterialPageRoute(
                             builder: (context) => SettingUserInfo(
                                   handlePhoneAuth: handlePhoneAuth,
+                                  userEmail: userEmail,
+                                  userNickname: userNickname,
                                 )));
                   },
                   title: Row(

--- a/lib/settings/view/s_setting_userinfo.dart
+++ b/lib/settings/view/s_setting_userinfo.dart
@@ -4,10 +4,18 @@ import 'package:me_mind/common/layout/topbar/widget/back_arrow.dart';
 import 'package:me_mind/common/theme/custom_theme.dart';
 import 'package:me_mind/common/theme/custom_theme_holder.dart';
 import 'package:me_mind/settings/view/f_userinfo_form.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class SettingUserInfo extends StatefulWidget {
   final VoidCallback handlePhoneAuth;
-  const SettingUserInfo({super.key, required this.handlePhoneAuth});
+  final String? userEmail;
+  final String? userNickname;
+
+  const SettingUserInfo(
+      {super.key,
+      required this.handlePhoneAuth,
+      this.userEmail,
+      this.userNickname});
 
   @override
   State<SettingUserInfo> createState() => _SettingUserInfoState();
@@ -50,8 +58,8 @@ class _SettingUserInfoState extends State<SettingUserInfo> {
                     isUpdate: isUpdate,
                     onUpdate: onUpdate,
                     handlePhoneAuth: widget.handlePhoneAuth,
-                    userEmail: email,
-                    userNickname: nickname,
+                    userEmail: widget.userEmail ?? email,
+                    userNickname: widget.userNickname ?? nickname,
                   ),
                 ),
               ),

--- a/lib/settings/view/s_setting_userinfo.dart
+++ b/lib/settings/view/s_setting_userinfo.dart
@@ -4,7 +4,6 @@ import 'package:me_mind/common/layout/topbar/widget/back_arrow.dart';
 import 'package:me_mind/common/theme/custom_theme.dart';
 import 'package:me_mind/common/theme/custom_theme_holder.dart';
 import 'package:me_mind/settings/view/f_userinfo_form.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class SettingUserInfo extends StatefulWidget {
   final VoidCallback handlePhoneAuth;
@@ -24,29 +23,10 @@ class _SettingUserInfoState extends State<SettingUserInfo> {
     });
   }
 
-  void getIsAuth() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-
-    String? isEmail = await prefs.getString('email');
-    String? isNickname = await prefs.getString('nickname');
-    print(isEmail);
-    if (isEmail != null) {
-      setState(() {
-        email = isEmail;
-      });
-    }
-    if (isNickname != null) {
-      setState(() {
-        nickname = isNickname;
-      });
-    }
-  }
-
   @override
   void initState() {
     // TODO: implement initState
     super.initState();
-    getIsAuth();
   }
 
   @override
@@ -58,7 +38,7 @@ class _SettingUserInfoState extends State<SettingUserInfo> {
         appBarLeading: isUpdate == false ? const BackArrowLeading() : null,
         backgroundColor: theme.appColors.seedColor,
         child: CustomScrollView(
-          physics: NeverScrollableScrollPhysics(),
+          physics: const NeverScrollableScrollPhysics(),
           slivers: [
             SliverFillRemaining(
               hasScrollBody: false,

--- a/lib/user/model/user_signin_model.dart
+++ b/lib/user/model/user_signin_model.dart
@@ -1,22 +1,22 @@
-class UserSignInModel {
-  final String code;
-  final String msg;
-  final SignInResult result;
+// class UserSignInModel {
+//   final String code;
+//   final String msg;
+//   final SignInResult result;
 
-  UserSignInModel({
-    required this.code,
-    required this.msg,
-    required this.result,
-  });
+//   UserSignInModel({
+//     required this.code,
+//     required this.msg,
+//     required this.result,
+//   });
 
-  factory UserSignInModel.fromJson(Map<String, dynamic> json) {
-    return UserSignInModel(
-      code: json['code'] as String,
-      msg: json['msg'] as String,
-      result: SignInResult.fromJson(json['result'] as Map<String, dynamic>),
-    );
-  }
-}
+//   factory UserSignInModel.fromJson(Map<String, dynamic> json) {
+//     return UserSignInModel(
+//       code: json['code'] as String,
+//       msg: json['msg'] as String,
+//       result: SignInResult.fromJson(json['result'] as Map<String, dynamic>),
+//     );
+//   }
+// }
 
 class SignInResult {
   final String accessToken;

--- a/lib/user/model/user_signin_model.dart
+++ b/lib/user/model/user_signin_model.dart
@@ -1,23 +1,3 @@
-// class UserSignInModel {
-//   final String code;
-//   final String msg;
-//   final SignInResult result;
-
-//   UserSignInModel({
-//     required this.code,
-//     required this.msg,
-//     required this.result,
-//   });
-
-//   factory UserSignInModel.fromJson(Map<String, dynamic> json) {
-//     return UserSignInModel(
-//       code: json['code'] as String,
-//       msg: json['msg'] as String,
-//       result: SignInResult.fromJson(json['result'] as Map<String, dynamic>),
-//     );
-//   }
-// }
-
 class SignInResult {
   final String accessToken;
   final String refreshToken;

--- a/lib/user/model/user_signup_model.dart
+++ b/lib/user/model/user_signup_model.dart
@@ -1,19 +1,13 @@
 class UserSignUpModel {
-  final String code;
   final String msg;
-  final String result;
 
   UserSignUpModel({
-    required this.code,
     required this.msg,
-    required this.result,
   });
 
   factory UserSignUpModel.fromJson(Map<String, dynamic> json) {
     return UserSignUpModel(
-      code: json['code'] as String,
       msg: json['msg'] as String,
-      result: json['result'] as String,
     );
   }
 }

--- a/lib/user/services/login_service.dart
+++ b/lib/user/services/login_service.dart
@@ -1,12 +1,12 @@
 import 'package:dio/dio.dart';
+import 'package:me_mind/common/constant/constant.dart';
 import 'package:me_mind/user/interface/auth_interface.dart';
 import 'package:me_mind/user/model/user_signin_model.dart';
 
 class LoginService implements ILogin {
   @override
   Future login(String email, String password) async {
-    // const url = "http://54.206.203.208/users/sign-in";
-    const url = "http://10.0.2.2:8000/users/sign-in";
+    final url = "http://$ip/login";
     final data = {"email": email, "password": password};
 
     final dio = Dio();
@@ -15,13 +15,9 @@ class LoginService implements ILogin {
     try {
       response = await dio.post(url, data: data);
       if (response.statusCode == 200) {
-        final body = response.data['result'];
-        print(body['result']);
-        return UserSignInModel(
-          code: body['code'],
-          msg: body['message'],
-          result: SignInResult.fromJson(body['result']),
-        );
+        final body = response.data;
+
+        return SignInResult.fromJson(body);
       } else {
         return null;
       }

--- a/lib/user/services/signup_service.dart
+++ b/lib/user/services/signup_service.dart
@@ -1,10 +1,12 @@
 import 'package:dio/dio.dart';
+import 'package:me_mind/common/constant/constant.dart';
 import 'package:me_mind/user/interface/auth_interface.dart';
 import 'package:me_mind/user/model/user_signup_model.dart';
 
 class SignupService implements Isignup {
   Future<dynamic> signup(String email, String password, String nickname) async {
-    const url = "http://10.0.2.2:8000/users/sign-up";
+    final url = "http://$ip/users/signup";
+
     final data = {
       "email": email,
       "password": password,
@@ -20,15 +22,14 @@ class SignupService implements Isignup {
 
       if (response.statusCode == 201) {
         var body = response.data;
-
-        return UserSignUpModel(
-            code: body["code"], msg: body["msg"], result: body["result"]);
+        return UserSignUpModel(msg: body["message"]);
       }
     } on DioException catch (e) {
-      if (e.response != null) {
-        return e.response!.data['detail'];
+      if (e.response!.statusCode == 400) {
+        return e.response!.data['message'];
+      } else {
+        return null;
       }
-      print("Dio Error");
     }
   }
 }

--- a/lib/user/services/signup_service.dart
+++ b/lib/user/services/signup_service.dart
@@ -4,7 +4,7 @@ import 'package:me_mind/user/interface/auth_interface.dart';
 import 'package:me_mind/user/model/user_signup_model.dart';
 
 class SignupService implements Isignup {
-  Future<dynamic> signup(String email, String password, String nickname) async {
+  Future<dynamic> signup(String email, String nickname, String password) async {
     final url = "http://$ip/users/signup";
 
     final data = {

--- a/lib/user/view/s_signin.dart
+++ b/lib/user/view/s_signin.dart
@@ -45,7 +45,7 @@ class _SignInScreenState extends State<SignInScreen> {
   Widget build(BuildContext context) {
     CustomTheme theme = CustomThemeHolder.of(context).theme;
 
-    final AuthService authService = AuthService(); // AuthService 인스턴스 생성
+    final AuthService authService = AuthService();
 
     return DefaultLayout(
         title: "로그인",
@@ -113,14 +113,13 @@ class _SignInScreenState extends State<SignInScreen> {
                             if (_formKey.currentState!.validate()) {
                               final response = await authService.loginService
                                   .login(email, password);
-                              print(response);
+
                               if (response == null) {
                                 setState(() {
                                   emailErrorText = "아이디 혹은 비밀번호가 다릅니다.";
                                   passwordErrorText = "아이디 혹은 비밀번호가 다릅니다.";
                                 });
                               } else {
-                                // 추후 토큰 저장 및 관리
                                 final refreshToken = response.refreshToken;
                                 final accessToken = response.accessToken;
 

--- a/lib/user/view/s_signin.dart
+++ b/lib/user/view/s_signin.dart
@@ -113,7 +113,7 @@ class _SignInScreenState extends State<SignInScreen> {
                             if (_formKey.currentState!.validate()) {
                               final response = await authService.loginService
                                   .login(email, password);
-
+                              print(response);
                               if (response == null) {
                                 setState(() {
                                   emailErrorText = "아이디 혹은 비밀번호가 다릅니다.";
@@ -121,9 +121,8 @@ class _SignInScreenState extends State<SignInScreen> {
                                 });
                               } else {
                                 // 추후 토큰 저장 및 관리
-                                final refreshToken =
-                                    response.result.refreshToken;
-                                final accessToken = response.result.accessToken;
+                                final refreshToken = response.refreshToken;
+                                final accessToken = response.accessToken;
 
                                 await storage.write(
                                     key: ACCESS_TOKEN, value: accessToken);

--- a/lib/user/view/signup_screen.dart
+++ b/lib/user/view/signup_screen.dart
@@ -357,8 +357,6 @@ class _SignUpScreenState extends State<SignUpScreen> {
                                                     Navigator.pop(context);
                                                   },
                                                 ))).show();
-                                        await Future.delayed(
-                                            const Duration(milliseconds: 1000));
                                       }
                                       if (isAppPush == true) {
                                         var permissonStatus =

--- a/lib/user/view/signup_screen.dart
+++ b/lib/user/view/signup_screen.dart
@@ -11,6 +11,7 @@ import 'package:me_mind/common/layout/topbar/widget/back_arrow.dart';
 import 'package:me_mind/common/theme/custom_theme.dart';
 import 'package:me_mind/common/theme/custom_theme_holder.dart';
 import 'package:me_mind/user/component/custom_checkbox.dart';
+import 'package:me_mind/user/model/user_signup_model.dart';
 import 'package:me_mind/user/services/signup_service.dart';
 import 'package:me_mind/user/view/s_signup_welcome.dart';
 import 'package:me_mind/utils/permission.dart';
@@ -338,7 +339,8 @@ class _SignUpScreenState extends State<SignUpScreen> {
                                           errorNameText = "이미 존재하는 닉네임입니다";
                                         });
                                       }
-                                    } else {
+                                    }
+                                    if (response is UserSignUpModel) {
                                       if (isAdvertising == true) {
                                         String today =
                                             DateFormat("yyyy년 MM월 dd일")
@@ -356,7 +358,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
                                                   },
                                                 ))).show();
                                         await Future.delayed(
-                                            Duration(milliseconds: 1000));
+                                            const Duration(milliseconds: 1000));
                                       }
                                       if (isAppPush == true) {
                                         var permissonStatus =


### PR DESCRIPTION
변경된 API 들에 맞춰 로그인 및 회원가입,
Dio Interceptor 활용하여 OnRequset 및 OnError를 사용한 토큰 관리
Splash Screen
 - token/refresh 실패시 refreshToken 만류이므로 다시 로그인 페이지
 - token/refresh 성공 시 발급받은 accessToken으로 유저 정보까지 불러오기
 - 유저 정보 불러온 후 메인 페이지로 이동